### PR TITLE
Create latest version folder

### DIFF
--- a/gruntfile.js
+++ b/gruntfile.js
@@ -44,6 +44,12 @@ module.exports = function(grunt) {
             cwd: 'build/',
             src: ['<%= pkg.name %>.min.js'],
             dest: '<%= aws.destination %>/<%= pkg.version %>/'
+          },
+          { action: 'upload',
+            expand: true,
+            cwd: 'build/',
+            src: ['**'],
+            dest: '<%= aws.destination %>/latest/'
           }
         ]
       },

--- a/gruntfile.js
+++ b/gruntfile.js
@@ -71,6 +71,6 @@ module.exports = function(grunt) {
   grunt.loadNpmTasks('grunt-jsdoc');
 
   grunt.registerTask('deploy', ['aws_s3']);
-  grunt.registerTask('default', ['jshint', 'karma', 'uglify', 'jsdoc']);
+  grunt.registerTask('default', ['jshint', 'karma', 'uglify']);
 
 };


### PR DESCRIPTION
For users who want to use always the latest version.
https://d335luupugsy2.cloudfront.net/js/integration/latest/rd-js-integration.min.js

@pedrovitti utilizamos esse link na nossa página de integrações?
Ou usamos sempre a current version?