### PR TITLE
New versioning

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,6 +30,16 @@ RD Station Integration uses Circle CI! Everytime you push anything to Github, Ci
 
 Gruntfile has a task `deploy` for deploying any `app/*.min.js` file into Amazon Cloudfront. In case you need to upload any other file to Amazon, you should add it to the `grunt deploy` task.
 
+When deploying, you have to set the environment you intend to deploy. Follow this:
+
+```
+grunt deploy--env=beta
+```
+
+```
+grunt deploy --env=stable
+```
+
 You may have noticed that the script wasn’t deployed after it has passed the tests. We made this choice due to secutiry reasons: The `grunt deploy` task needs the Amazon credentials. Since the repository is public, it's not safe to reveal company credentials in it. To avoid test errors, you will find at project files a `.json` with generic credentials for amazon: `/.aws_credentials.json`.
 
 To make deploy task works, fill `.aws_credentials` with your Amazon S3 credentials.

--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ Gruntfile has a task `deploy` for deploying any `app/*.min.js` file into Amazon 
 When deploying, you have to set the environment you intend to deploy. Follow this:
 
 ```
-grunt deploy--env=beta
+grunt deploy --env=beta
 ```
 
 ```

--- a/gruntfile.js
+++ b/gruntfile.js
@@ -34,7 +34,7 @@ module.exports = function(grunt) {
         progress: 'dots',
         region: 'sa-east-1'
       },
-      production: {
+      beta: {
         options: {
           bucket: '<%= aws.bucket %>'
         },
@@ -43,13 +43,20 @@ module.exports = function(grunt) {
             expand: true,
             cwd: 'build/',
             src: ['<%= pkg.name %>.min.js'],
-            dest: '<%= aws.destination %>/<%= pkg.version %>/'
+            dest: '<%= aws.destination %>/beta/'
           },
+        ]
+      },
+      production: {
+        options: {
+          bucket: '<%= aws.bucket %>'
+        },
+        files: [
           { action: 'upload',
             expand: true,
             cwd: 'build/',
             src: ['**'],
-            dest: '<%= aws.destination %>/latest/'
+            dest: '<%= aws.destination %>/stable/'
           }
         ]
       },
@@ -70,7 +77,8 @@ module.exports = function(grunt) {
   grunt.loadNpmTasks('grunt-aws-s3');
   grunt.loadNpmTasks('grunt-jsdoc');
 
-  grunt.registerTask('deploy', ['aws_s3']);
+  var env = grunt.option('env') || 'beta';
+  grunt.registerTask('deploy', ['aws_s3:' + env]);
   grunt.registerTask('default', ['jshint', 'karma', 'uglify']);
 
 };

--- a/gruntfile.js
+++ b/gruntfile.js
@@ -47,7 +47,7 @@ module.exports = function(grunt) {
           },
         ]
       },
-      production: {
+      stable: {
         options: {
           bucket: '<%= aws.bucket %>'
         },


### PR DESCRIPTION
A tarefa automatizada de deploy teve ter opção para deployar para a pasta `beta` ou para a pasta `stable`.

- [ ] Tarefa automatizada para deploy na pasta `beta`
- [ ] Tarefa automatizada para deploy na pasta `stable`
- [ ] Atualizar Readme

Por padrão, o deploy é feito na pasta beta.

Para definir a pasta para a qual será feito o deploy, deve setar a variável `env`:

`grunt deploy --env=beta`

`grunt deploy --env=stable`

## Como testar?

Pedir suas AWS S3 Credentials para o Brentan caso você ainda não tenha e fazer deploy nos dois ambientes. Verificar se funciona.

