### PR TITLE
add traffic_source param

### DIFF
--- a/app/rd-js-integration.js
+++ b/app/rd-js-integration.js
@@ -87,7 +87,7 @@ var RdIntegration = (function () {
       inputs = _removeNotAllowedFields(inputs);
       inputs = inputs.serializeArray();
       inputs = _fieldMap(inputs);
-      inputs.push($accountSettings.identifier, $accountSettings.token, $accountSettings.c_utmz, _getReferrer(), _getQueryParams());
+      inputs.push($accountSettings.identifier, $accountSettings.token, $accountSettings.c_utmz, $accountSettings.traffic_source, _getReferrer(), _getQueryParams());
       return inputs;
     },
 
@@ -147,6 +147,10 @@ var RdIntegration = (function () {
         c_utmz: {
           name: 'c_utmz',
           value: _read_cookie('__utmz')
+        },
+        traffic_source: {
+          name: 'traffic_source',
+          value: _read_cookie('__trf.src')
         }
       };
     },


### PR DESCRIPTION
Adiciona o novo parâmetro traffic_source. Ela irá ser preenchido com o valor do nosso cookie `__trf.src`.

### Testes

- [x] Integração com a presença do cookie `__trf.src` envia a informação para o Station
- [x] Integração sem a presença do cookie `__trf.src` mas com `__utmz` envia a informação do c_utmz para o Station
